### PR TITLE
Backfill yet another

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -17,8 +17,8 @@ module.exports = {
       }
     },
     {
-      name: "backfill-sequencer",
-      script: "./build/command/backfill_sequencer.js",
+      name: "backfill",
+      script: "./build/command/backfill.js",
       args: "--mariadb-database whirlpool --solana-rpc-url http://localhost:8899 -n 100",
       env: {
         NODE_ENV: "production",

--- a/src/command/backfill.ts
+++ b/src/command/backfill.ts
@@ -10,7 +10,7 @@ async function main() {
   addConnectionOptions(program, true, true, true);
   program
     .option("-q --max-queued-slots <max>", "max queued slots", "10000")
-    .option("-n --new-slot-per-fetch <max>", "new slots per fetch", "1000");
+    .option("-n --new-slot-per-fetch <max>", "new slots per fetch", "500");
 
   const options = program.parse().opts();
 

--- a/src/command/backfill.ts
+++ b/src/command/backfill.ts
@@ -40,7 +40,7 @@ async function main() {
   });
 
   console.log("build worker...");
-  const worker = new Worker<undefined, void>(WorkerQueueName.BACKFILL_SEQUENCER, async (job) => {
+  const worker = new Worker<undefined, void>(WorkerQueueName.BACKFILL, async (job) => {
     console.info("job consuming...");
 
     let db: mariadb.Connection;

--- a/src/command/bullboard.ts
+++ b/src/command/bullboard.ts
@@ -22,7 +22,7 @@ const redis: ConnectionOptions = {
 };
 
 const queueSequencer = new Queue<undefined, void>(WorkerQueueName.SEQUENCER, { connection: redis });
-const queueBackfillSequencer = new Queue<undefined, void>(WorkerQueueName.BACKFILL_SEQUENCER, { connection: redis });
+const queueBackfill = new Queue<undefined, void>(WorkerQueueName.BACKFILL, { connection: redis });
 const queueProcessor = new Queue<number, void>(WorkerQueueName.PROCESSOR, { connection: redis });
 
 const serverAdapter = new ExpressAdapter();
@@ -31,7 +31,7 @@ serverAdapter.setBasePath('/admin/queues');
 const { addQueue, removeQueue, setQueues, replaceQueues } = createBullBoard({
   queues: [
     new BullMQAdapter(queueSequencer),
-    new BullMQAdapter(queueBackfillSequencer),
+    new BullMQAdapter(queueBackfill),
     new BullMQAdapter(queueProcessor),
   ],
   serverAdapter: serverAdapter,

--- a/src/command/dispatcher.ts
+++ b/src/command/dispatcher.ts
@@ -37,18 +37,18 @@ async function main() {
   const defaultJobOptions = { removeOnComplete: 1000, removeOnFail: 1000 };
 
   const queueSequencer = new Queue<undefined, void>(WorkerQueueName.SEQUENCER, { connection: redis, defaultJobOptions });
-  const queueBackfillSequencer = new Queue<undefined, void>(WorkerQueueName.BACKFILL_SEQUENCER, { connection: redis, defaultJobOptions });
+  const queueBackfill = new Queue<undefined, void>(WorkerQueueName.BACKFILL, { connection: redis, defaultJobOptions });
   const queueProcessor = new Queue<number, void>(WorkerQueueName.PROCESSOR, { connection: redis, defaultJobOptions });
 
   // reset queue
   console.info("reset queue...");
   await queueSequencer.obliterate({force: true});
-  await queueBackfillSequencer.obliterate({force: true});
+  await queueBackfill.obliterate({force: true});
   await queueProcessor.obliterate({force: true});
 
-  console.info("add sequencer repeated job...");
+  console.info("add repeated job...");
   queueSequencer.add("sequencer repeated", undefined, { repeat: { every: dispatchInterval } });
-  queueBackfillSequencer.add("backfill sequencer repeated", undefined, { repeat: { every: dispatchInterval } });
+  queueBackfill.add("backfill repeated", undefined, { repeat: { every: dispatchInterval } });
 
   // graceful shutdown
   process.on("SIGINT", async () => {

--- a/src/command/dispatcher.ts
+++ b/src/command/dispatcher.ts
@@ -80,7 +80,7 @@ async function main() {
         }
       });
 
-      const backfillRows = await db.query<Pick<Slot, "slot">[]>('SELECT slot FROM admQueuedSlots WHERE isBackfillSlot IS TRUE ORDER BY queuedAt ASC LIMIT ?', [processorMax]);
+      const backfillRows = await db.query<Pick<Slot, "slot">[]>('SELECT slot FROM admQueuedSlots WHERE isBackfillSlot IS TRUE ORDER BY slot DESC LIMIT ?', [processorMax]);
       backfillRows.forEach(row => {
         if (!enqueuedSlotSet.has(row.slot)) {
           queueProcessor.add(`block_processor(slot=${row.slot},backfill=true)`, row.slot, { priority: 1 });

--- a/src/command/sequencer.ts
+++ b/src/command/sequencer.ts
@@ -10,7 +10,7 @@ async function main() {
   addConnectionOptions(program, true, true, true);
   program
     .option("-q --max-queued-slots <max>", "max queued slots", "10000")
-    .option("-n --new-slot-per-fetch <max>", "new slots per fetch", "1000");
+    .option("-n --new-slot-per-fetch <max>", "new slots per fetch", "200");
 
   const options = program.parse().opts();
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,6 +1,6 @@
 export enum WorkerQueueName {
   SEQUENCER = "sequencer",
-  BACKFILL_SEQUENCER = "backfill_sequencer",
+  BACKFILL = "backfill",
   PROCESSOR = "processor",
 }
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -15,8 +15,7 @@ export type Slot = {
   blockTimestamp: number | null;
 };
 
-export type BackfillState = {
-  maxBlockHeight: number;
-  latestBlockSlot: number;
-  latestBlockHeight: number;
+export type BackfillSlot = {
+  slot: number;
+  blockHeight: number;
 };

--- a/src/sql/definition.sql
+++ b/src/sql/definition.sql
@@ -18,18 +18,14 @@ CREATE TABLE `admState` (
 CREATE TABLE `admQueuedSlots` (
   `slot` bigint(11) unsigned NOT NULL,
   `blockHeight` bigint(11) unsigned NOT NULL,
-  `queuedAt` bigint(11) unsigned NOT NULL,
   `isBackfillSlot` tinyint(1) unsigned NOT NULL,
   PRIMARY KEY (`slot`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
-CREATE TABLE `admBackfillState` (
-  `enabled` tinyint(1) unsigned NOT NULL,
-  `maxBlockHeight` bigint(11) unsigned NOT NULL,
-  `minBlockHeight` bigint(11) unsigned NOT NULL,
-  `latestBlockSlot` bigint(11) unsigned NOT NULL,
-  `latestBlockHeight` bigint(11) unsigned NOT NULL,
-  PRIMARY KEY (`maxBlockHeight`)
+CREATE TABLE `admBackfillSlots` (
+  `slot` bigint(11) unsigned NOT NULL,
+  `blockHeight` bigint(11) unsigned NOT NULL,
+  PRIMARY KEY (`slot`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
 CREATE TABLE `slots` (

--- a/src/worker/fetch_backfill_slots.ts
+++ b/src/worker/fetch_backfill_slots.ts
@@ -1,6 +1,6 @@
 import { Connection } from "mariadb";
 import { AxiosInstance } from "axios";
-import { BackfillState } from "../common/types";
+import { BackfillSlot } from "../common/types";
 import invariant from "tiny-invariant";
 
 export async function fetchBackfillSlots(database: Connection, solana: AxiosInstance, limit: number, maxQueuedSlots: number) {
@@ -11,52 +11,15 @@ export async function fetchBackfillSlots(database: Connection, solana: AxiosInst
     return;
   }
 
-  const [backfillState] = await database.query<BackfillState[]>('SELECT * FROM admBackfillState WHERE enabled IS TRUE AND latestBlockHeight < maxBlockHeight ORDER BY maxBlockHeight DESC LIMIT 1');
+  const backfillSlots = await database.query<BackfillSlot[]>('SELECT * FROM admBackfillSlots ORDER BY slot DESC LIMIT ?', [limit]);
 
-  if (!backfillState) {
+  if (backfillSlots.length === 0) {
     // no backfill required
     return;
   }
 
-  const { maxBlockHeight, latestBlockSlot, latestBlockHeight } = backfillState;
-
-  // getBlocksWithLimit
-  // see: https://docs.solana.com/api/http#getblockswithlimit
-  const response = await solana.request({
-    data: {
-      jsonrpc: "2.0",
-      id: 1,
-      method: "getBlocksWithLimit",
-      params: [
-        latestBlockSlot,
-        limit + 1, // latestBlockSlot is included
-        { commitment: "finalized" },
-      ],
-    },
-  });
-
-  if (response.data?.error) {
-    throw new Error(`getBlocksWithLimit(${latestBlockSlot}, ${limit}) failed: ${JSON.stringify(response.data.error)}`);
-  }
-  invariant(response.data?.result, "result must be truthy");
-
-  const slots: number[] = response.data.result;
-
-  invariant(slots.length >= 1, "at least latestBlockSlot should be returned");
-  invariant(slots[0] === latestBlockSlot, "first slot should be latestBlockSlot");
-
-  if (slots.length === 1) {
-    // no new blocks
-    return;
-  }
-
-  const newSlots = slots.map((slot, delta) => ({ slot, blockHeight: latestBlockHeight + delta }))
-    .filter(s => s.blockHeight <= maxBlockHeight)
-    .slice(1);
-  const newLatestSlot = newSlots[newSlots.length - 1];
-
   await database.beginTransaction();
-  await database.query("UPDATE admBackfillState SET latestBlockSlot = ?, latestBlockHeight = ? WHERE maxBlockHeight = ? AND latestBlockSlot = ?", [newLatestSlot.slot, newLatestSlot.blockHeight, maxBlockHeight, latestBlockSlot]);
-  await database.batch("INSERT INTO admQueuedSlots (slot, blockHeight, queuedAt, isBackfillSlot) VALUES (?, ?, UNIX_TIMESTAMP(), ?)", newSlots.map(s => [s.slot, s.blockHeight, true]));
+  await database.batch("DELETE FROM admBackfillSlots WHERE slot = ?", backfillSlots.map(s => [s.slot]));
+  await database.batch("INSERT INTO admQueuedSlots (slot, blockHeight, isBackfillSlot) VALUES (?, ?, ?)", backfillSlots.map(s => [s.slot, s.blockHeight, true]));
   await database.commit();
 }

--- a/src/worker/fetch_slots.ts
+++ b/src/worker/fetch_slots.ts
@@ -48,6 +48,6 @@ export async function fetchSlots(database: Connection, solana: AxiosInstance, li
 
   await database.beginTransaction();
   await database.query("UPDATE admState SET latestBlockSlot = ?, latestBlockHeight = ? WHERE latestBlockSlot = ?", [newLatestSlot.slot, newLatestSlot.blockHeight, latestBlockSlot]);
-  await database.batch("INSERT INTO admQueuedSlots (slot, blockHeight, queuedAt, isBackfillSlot) VALUES (?, ?, UNIX_TIMESTAMP(), ?)", newSlots.map(s => [s.slot, s.blockHeight, false]));
+  await database.batch("INSERT INTO admQueuedSlots (slot, blockHeight, isBackfillSlot) VALUES (?, ?, ?)", newSlots.map(s => [s.slot, s.blockHeight, false]));
   await database.commit();
 }


### PR DESCRIPTION
- getBlocks & getBlocksWithLimit are too slow when slot is too old (maybe they are processed by BigQuery)
- We can retrieve slot and its height from BigQuery directly, so use it.

Solana x BigQuery: https://console.cloud.google.com/marketplace/product/bigquery-public-data/crypto-solana-mainnet-us?project=portfolio-313610